### PR TITLE
It fixes T1018, Remote System Discovery - sweep 

### DIFF
--- a/atomics/T1018/T1018.yaml
+++ b/atomics/T1018/T1018.yaml
@@ -69,7 +69,7 @@ atomic_tests:
     name: sh
     elevation_required: false
     command: |
-      for ip in $(seq 1 254); do ping -c 1 192.168.1.$ip -o; [ $? -eq 0 ] && echo "192.168.1.$ip UP" || : ; done
+      for ip in $(seq 1 254); do ping -c 1 192.168.1.$ip; [ $? -eq 0 ] && echo "192.168.1.$ip UP" || : ; done
       
 - name: Remote System Discovery - nslookup
   description: |


### PR DESCRIPTION
**Details:**
The `-o` flag exists only for the MacOs ping command, it doesn't in the Linux (Ubuntu) command.

I just removed it, it should be necessary since it is already using `-c 1`.

**Testing:**
Tested it on Ubuntu 18.04

**Associated Issues:**